### PR TITLE
add resource id to be able to pass as a parameter to datapub

### DIFF
--- a/ckanext/external_storage/templates/external_storage/snippets/upload_module.html
+++ b/ckanext/external_storage/templates/external_storage/snippets/upload_module.html
@@ -9,5 +9,6 @@
      data-api="{{ base_url }}"
      data-lfs="{{ h.extstorage_lfs_url() }}"
      data-auth-token="{{ api_key }}"
-     data-organization-id="{{ h.extstorage_organization_name(pkg_name) }}">
+     data-organization-id="{{ h.extstorage_organization_name(pkg_name) }}"
+     data-resource-id="{{ resource_id }}">
 </div>

--- a/ckanext/external_storage/templates/package/resource_edit.html
+++ b/ckanext/external_storage/templates/package/resource_edit.html
@@ -1,5 +1,5 @@
 {% ckan_extends %}
 
 {% block form %}
-  {% snippet 'external_storage/snippets/upload_module.html', pkg_name=pkg.name, parent=super %}
+  {% snippet 'external_storage/snippets/upload_module.html', resource_id=res.id, pkg_name=pkg.name, parent=super %}
 {% endblock %}


### PR DESCRIPTION
Datapub expects to receive a parameter `data-resource-id` with the id of the resource when the user is editing resources.
 
More information you can check in https://github.com/datopian/datapub/issues/37