### PR TITLE
[tests][s]: add tests for new actions - #32

### DIFF
--- a/ckanext/external_storage/tests/__init__.py
+++ b/ckanext/external_storage/tests/__init__.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Any, Dict
 
-from ckan import model
+from ckan import model as core_model
 from ckan.tests import helpers
 from mock import patch
 
@@ -11,6 +11,16 @@ class FunctionalTestBase(helpers.FunctionalTestBase):
     _load_plugins = ['external_storage']
 
 
+def get_context(user):
+    userobj = core_model.User.get(user['name'])
+    return {
+        'model': core_model,
+        'user': user['name'],
+        "auth_user_obj": userobj,
+        'ignore_auth': False
+    }
+
+
 @contextmanager
 def user_context(user):
     # type: (Dict[str, Any]) -> Dict[str, Any]
@@ -18,8 +28,8 @@ def user_context(user):
     both patches our `get_user_context` function to return it and also
     yields the context for use inside tests
     """
-    userobj = model.User.get(user['name'])
-    context = {"model": model,
+    userobj = core_model.User.get(user['name'])
+    context = {"model": core_model,
                "user": user['name'],
                "auth_user_obj": userobj,
                "userobj": userobj}

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -1,0 +1,72 @@
+from ckan.tests import factories
+from ckan.tests import helpers as test_helpers
+
+from ckanext.external_storage.tests import get_context
+
+
+class TestBlobSotrageActions():
+    """Test cases for logic actions
+    """
+
+    org_admin = factories.User()
+    initial_dataset = factories.Dataset()
+
+    first_resource = factories.Resource(
+        name="First Resource",
+        package_id=initial_dataset['id'],
+        sample="{u'1': {u'VMP_SNOMED_CODE': u'4747111000001104', u'ODS_CODE': u'REF'}}",
+        schema="{u'fields': [{u'type': u'string'}], u'missingValues': [u'']}"
+    )
+
+    second_resource = factories.Resource(
+        name="First Resource",
+        package_id=initial_dataset['id'],
+        sample={'1': {'VMP_SNOMED_CODE': '4747111000001104'}},
+        schema={'fields': [{'type': 'string'}], 'missingValues': ['']}
+    )
+
+    def test_resource_schema_show(self):
+        """Test if the resource.schema is a string the resource_sample_show should return JSON object
+        """
+        context = get_context(self.org_admin)
+        expect = {'fields': [{'type': 'string'}], 'missingValues': ['']}
+
+        resource_schema = test_helpers.call_action(
+            'resource_schema_show',
+            context,
+            id=self.first_resource['id'])
+
+        assert resource_schema == expect
+
+    def test_resource_sample_show(self):
+        """Test if the resource.sample is a string the resource_sample_show should return JSON object
+        """
+        context = get_context(self.org_admin)
+        expect = {'1': {'VMP_SNOMED_CODE': '4747111000001104', 'ODS_CODE': 'REF'}}
+
+        resource_sample = test_helpers.call_action(
+            'resource_sample_show',
+            context,
+            id=self.first_resource['id'])
+
+        assert resource_sample == expect
+
+    def test_resource_schema_show_and_resource_sample_show_with_new_ckan_version(self):
+        """Test with CKAN version >=2.8.5 should not be broken if is already a JSON object
+        """
+        context = get_context(self.org_admin)
+        expect_sample = {'1': {'VMP_SNOMED_CODE': '4747111000001104'}}
+        expect_schema = {'fields': [{'type': 'string'}], 'missingValues': ['']}
+
+        resource_sample = test_helpers.call_action(
+            'resource_sample_show',
+            context,
+            id=self.second_resource['id'])
+
+        resource_schema = test_helpers.call_action(
+            'resource_schema_show',
+            context,
+            id=self.second_resource['id'])
+
+        assert resource_sample == expect_sample
+        assert resource_schema == expect_schema


### PR DESCRIPTION
Create tests to cover the actions `resource_sample_show` and `resource_schema_show` after the PR https://github.com/datopian/ckanext-blob-storage/pull/30

- [x] Add test for  `resource_sample_show`
- [x] Add test for  `resource_schema_show`
