### PR TITLE
Translate full resource scope to storage scope using scope modifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CKAN_SOLR_PASSWORD := ckan
 DATASTORE_DB_NAME := datastore
 DATASTORE_DB_RO_USER := datastore_ro
 DATASTORE_DB_RO_PASSWORD := datastore_ro
-CKAN_LOAD_PLUGINS := external_storage authz_service stats text_view image_view recline_view datastore
+CKAN_LOAD_PLUGINS := stats text_view image_view recline_view datastore authz_service external_storage
 
 CKAN_CONFIG_VALUES := \
 		ckan.site_url=$(CKAN_SITE_URL) \

--- a/ckanext/external_storage/actions.py
+++ b/ckanext/external_storage/actions.py
@@ -1,13 +1,16 @@
 """External Storage API actions
 """
 import ast
-from typing import Any, Dict
+import logging
+from typing import Any, Dict, Optional
 
 from ckan.plugins import toolkit
 from giftless_client import LfsClient
 from giftless_client.exc import LfsError
 
 from . import helpers
+
+log = logging.getLogger(__name__)
 
 
 @toolkit.side_effect_free
@@ -19,16 +22,49 @@ def get_resource_download_spec(context, data_dict):
         if k not in resource:
             return {}
 
-    client = get_lfs_client(context, resource)
-    object = _get_resource_download_lfs_objects(client, resource['lfs_prefix'], [resource])[0]
-    assert object['oid'] == resource['sha256']
-    assert object['size'] == resource['size']
+    return get_lfs_download_spec(context, resource)
 
-    if 'error' in object:
-        raise toolkit.ObjectNotFound('Object error [{}]: {}'.format(object['error'].get('message', '[no message]'),
-                                                                    object['error'].get('code', 'unknown')))
 
-    return object['actions']['download']
+def get_lfs_download_spec(context,  # type: Dict[str, Any]
+                          resource,  # type: Dict[str, Any]
+                          sha256=None,  # type: Optional[str]
+                          size=None,  # type: Optional[int]
+                          filename=None,  # type: Optional[str]
+                          storage_prefix=None  # type: Optional[str]
+                          ):  # type: (...) -> Dict[str, Any]
+    """Get the LFS download spec (URL and headers) for a resource
+
+    This function allows overriding the expected sha256 and size for situations where
+    an additional file is associated with a CKAN resource and we want to override it.
+    In these cases, we will use the parent resource for authorization checks and
+    sha256 and size to request an object from the LFS server. You should *only* use
+    these override arguments if you know what you are doing, as allowing client side
+    code to override the sha256 and size could lead to potential security issues.
+    """
+    if storage_prefix is None:
+        storage_prefix = resource['lfs_prefix']
+    if size is None:
+        size = resource['size']
+    if sha256 is None:
+        sha256 = resource['sha256']
+    if filename is None:
+        filename = helpers.resource_filename(resource)
+
+    package = toolkit.get_action('package_show')(context, {'id': resource['package_id']})
+    authz_token = get_download_authz_token(context, package['organization']['name'], package['name'], resource['id'])
+    client = context.get('download_lfs_client', LfsClient(helpers.server_url(), authz_token))
+
+    resources = [{"oid": sha256, "size": size, "x-filename": filename}]
+    object_spec = _get_resource_download_lfs_objects(client, storage_prefix, resources)[0]
+
+    assert object_spec['oid'] == sha256
+    assert object_spec['size'] == size
+
+    if 'error' in object_spec:
+        raise toolkit.ObjectNotFound('Object error [{}]: {}'.format(object_spec['error'].get('message', '[no message]'),
+                                                                    object_spec['error'].get('code', 'unknown')))
+
+    return object_spec['actions']['download']
 
 
 @toolkit.side_effect_free
@@ -59,48 +95,39 @@ def resource_sample_show(context, data_dict):
     return {}
 
 
-def get_lfs_client(context, resource):
-    """Get an LFS client object; This is a poor man's DI solution
-    that allows injecting an LFS client object via the CKAN context
-    """
-    return context.get('lfs_client', LfsClient(helpers.server_url(), get_authz_token(context, resource)))
-
-
 def _get_resource_download_lfs_objects(client, lfs_prefix, resources):
     """Get LFS download operation response objects for a given resource list
     """
-    objects = [{"oid": r['sha256'],
-                "size": r['size'],
-                "x-filename": helpers.resource_filename(r)} for r in resources]
+    log.debug("Requesting download spec from LFS server for %s", resources)
     try:
-        batch_response = client.batch(lfs_prefix, 'download', objects)
+        batch_response = client.batch(lfs_prefix, 'download', resources)
     except LfsError as e:
         if e.status_code == 404:
             raise toolkit.ObjectNotFound("The requested resource does not exist")
         elif e.status_code == 422:
             raise toolkit.ObjectNotFound("Object parameters mismatch")
         elif e.status_code == 403:
-            raise toolkit.NotAuthorized("You are not authorized to download this resource")
+            raise toolkit.ObjectNotFound("Request was denied by the LFS server")
         else:
             raise
 
     return batch_response['objects']
 
 
-def get_authz_token(context, resource):
-    # type: (Dict[str, Any], Dict[str, Any]) -> str
-    """Get an authorization token for getting the URL from LFS
+def get_download_authz_token(context, org_name, package_name, resource_id):
+    # type: (Dict[str, Any], str, str, str) -> str
+    """Get an authorization token for getting the download URL from LFS
     """
     authorize = toolkit.get_action('authz_authorize')
     if not authorize:
         raise RuntimeError("Cannot find authz_authorize; Is ckanext-authz-service installed?")
 
-    org_name, package_name = resource['lfs_prefix'].split('/')
-    scope = helpers.resource_authz_scope(package_name, org_name=org_name, actions='read')
+    scope = helpers.resource_authz_scope(package_name, org_name=org_name, actions='read', resource_id=resource_id)
+    log.debug("Requesting authorization token for scope: %s", scope)
     authz_result = authorize(context, {"scopes": [scope]})
-
     if not authz_result or not authz_result.get('token', False):
         raise RuntimeError("Failed to get authorization token for LFS server")
+    log.debug("Granted scopes: %s", authz_result['granted_scopes'])
 
     if len(authz_result['granted_scopes']) == 0:
         raise toolkit.NotAuthorized("You are not authorized to download this resource")

--- a/ckanext/external_storage/authz.py
+++ b/ckanext/external_storage/authz.py
@@ -1,0 +1,54 @@
+"""Authorization related helpers
+"""
+import logging
+
+from ckan.plugins import toolkit
+
+from ckanext.authz_service.authz_binding.common import get_user_context
+from ckanext.authz_service.authzzie import Scope
+
+log = logging.getLogger(__name__)
+
+
+def normalize_object_scope(_, granted_scope):
+    # type: (Scope, Scope) -> Scope
+    """Normalize resource scope by trimming out the org/dataset part and only leaving the sha256
+
+    This helps us deal with cases where a resource is moved (i.e. the dataset is renamed, or the
+    organization is renamed, or the dataset is moved to a different organization)
+    """
+    if not granted_scope:
+        return granted_scope
+
+    entity_ref_parts = granted_scope.entity_ref.split('/')
+
+    # let's check that we have a full scope
+    if len(entity_ref_parts) < 3:
+        return granted_scope
+    for part in entity_ref_parts:
+        if part is None or part in {'', '*'}:
+            return granted_scope
+
+    storage_id = _get_resource_storage_id(organization_id=entity_ref_parts[0],
+                                          dataset_id=entity_ref_parts[1],
+                                          resource_id=entity_ref_parts[2])
+    return Scope(granted_scope.entity_type, storage_id, granted_scope.actions, granted_scope.subscope)
+
+
+def _get_resource_storage_id(organization_id, dataset_id, resource_id):
+    # type: (str, str, str) -> str
+    """Get the exact ID of the resource in storage, as opposed to it's ID in CKAN
+
+    A resource in CKAN is identified by <org_id>/<dataset_id>/<resource_id>. However,
+    the <org_id> and <dataset_id> can change if the dataset is renamed or moved or the
+    organization is renamed. For this reason, we replace the original CKAN ID with a
+    "static" ID composed if <lfs_prefix>/<sha256>. <lfs_prefix> in turn is the
+    <org_id>/<dataset_id> that the dataset had *when it was originally uploaded*, and
+    does not change over time.
+    """
+    dataset = toolkit.get_action('package_show')(get_user_context(), {'id': dataset_id})
+    for res in dataset['resources']:
+        if res['id'] == resource_id and res.get('sha256') and res.get('lfs_prefix'):
+            return '{}/{}'.format(res['lfs_prefix'], res['sha256'])
+
+    return '{}/{}/{}'.format(organization_id, dataset_id, resource_id)

--- a/ckanext/external_storage/cli.py
+++ b/ckanext/external_storage/cli.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 from contextlib import contextmanager
 from datetime import datetime
-
 from typing import Any, Dict, Generator, Tuple
 
 import requests

--- a/ckanext/external_storage/helpers.py
+++ b/ckanext/external_storage/helpers.py
@@ -34,13 +34,15 @@ def resource_storage_prefix(package_name, org_name=None):
     return '{}/{}'.format(org_name, package_name)
 
 
-def resource_authz_scope(package_name, actions=None, org_name=None):
-    # type: (str, Optional[str], Optional[str]) -> str
+def resource_authz_scope(package_name, actions=None, org_name=None, resource_id=None):
+    # type: (str, Optional[str], Optional[str], Optional[str]) -> str
     """Get the authorization scope for package resources
     """
     if actions is None:
         actions = 'read,write'
-    return 'obj:{}/*:{}'.format(resource_storage_prefix(package_name, org_name), actions)
+    if resource_id is None:
+        resource_id = '*'
+    return 'obj:{}/{}:{}'.format(resource_storage_prefix(package_name, org_name), resource_id, actions)
 
 
 def server_url():

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -1,9 +1,10 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
+from ckanext.authz_service.authzzie import Authzzie
 from ckanext.authz_service.interfaces import IAuthorizationBindings
 
-from . import actions, helpers
+from . import actions, authz, helpers
 from .blueprints import blueprint
 from .download_handler import download_handler
 from .interfaces import IResourceDownloadHandler
@@ -49,6 +50,7 @@ class ExternalStoragePlugin(plugins.SingletonPlugin):
     # IAuthorizationBindings
 
     def register_authz_bindings(self, authorizer):
+        # type: (Authzzie) -> None
         """Authorization Bindings
 
         This aliases CKANs Resource entity and actions to scopes understood by
@@ -56,6 +58,7 @@ class ExternalStoragePlugin(plugins.SingletonPlugin):
         """
         authorizer.register_type_alias('obj', 'res')
         authorizer.register_action_alias('write', 'update', 'res')
+        authorizer.register_scope_normalizer('res', authz.normalize_object_scope)
 
     # IResourceDownloadHandler
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,15 +41,19 @@ services:
 
   giftless:
     image: datopian/giftless
-    command: ["-s", "0.0.0.0:5000", "-M", "-T", "--threads", "2", "-p", "2", "--manage-script-name", "--callable", "app"]
+    command: ["--http", "0.0.0.0:9419", "-M", "-T", "--threads", "2", "-p", "2", "--manage-script-name", "--callable", "app"]
     environment:
       - GIFTLESS_CONFIG_FILE=/etc/giftless.yaml
+      - GIFTLESS_DEBUG=true
     volumes:
       - ./docker/giftless.yaml:/etc/giftless.yaml:ro
-
-  nginx:
-    image: nginx:1.13
-    volumes:
-      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ../giftless:/app  # Use local giftless
     ports:
-      - "9419:80"
+      - "9419:9419"
+
+#  nginx:
+#    image: nginx:1.13
+#    volumes:
+#      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+#    ports:
+#      - "9419:80"

--- a/docker/giftless.yaml
+++ b/docker/giftless.yaml
@@ -6,7 +6,7 @@ AUTH_PROVIDERS:
     options:
       algorithm: HS256
       private_key: this-is-a-test-only-key
-  - giftless.auth.allow_anon:read_only
+#  - giftless.auth.allow_anon:read_only
 
 # In a local environment we'll use the default storage adapter
 TRANSFER_ADAPTERS: {}
@@ -15,3 +15,11 @@ TRANSFER_ADAPTERS: {}
 PRE_AUTHORIZED_ACTION_PROVIDER:
   options:
     private_key: another-test-only-key
+
+# Enable CORS requests from localhost:5000
+MIDDLEWARE:
+  - class: wsgi_cors_middleware:CorsMiddleware
+    kwargs:
+      origin: http://localhost:5000
+      headers: ['Content-type', 'Accept', 'Authorization']
+      methods: ['GET', 'POST', 'PUT']


### PR DESCRIPTION
This is a different approach to fix #45. It relies on ckanext-authz-service 0.1.4+ and possibly fixes in Giftless, and will send the "in storage" path to the object as authorized scope instead of the "in CKAN" path to the object. 