### PR TITLE
[WIP] Storage fields validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SED := $(shell which gsed sed | head -n1)
 CKAN_CLI := $(shell which ckan | head -n1)
 
 TEST_INI_PATH := ./test.ini
+TEST_PATH :=
 SENTINELS := .make-status
 
 PYTHON_VERSION := $(shell $(PYTHON) -c 'import sys; print(sys.version_info[0])')
@@ -252,7 +253,8 @@ $(SENTINELS)/tests-passed: $(SENTINELS)/test-setup $(shell find $(PACKAGE_DIR) -
 		--ckan-ini=$(TEST_INI_PATH) \
 		--doctest-modules \
 		--ignore $(PACKAGE_DIR)/cli.py  \
-		$(PACKAGE_DIR)
+		-s \
+		$(PACKAGE_DIR)/$(TEST_PATH)
 	@touch $@
 
 # Help related variables and targets

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -35,6 +35,10 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'sha256': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('valid_sha256')
+            ],
+            'size': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('is_positive_integer'),
             ]
         })
 
@@ -53,6 +57,10 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'sha256': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('valid_sha256')
+            ],
+            'size': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('is_positive_integer'),
             ]
         })
 

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -39,6 +39,10 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'size': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('is_positive_integer'),
+            ],
+            'lfs_prefix': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_lfs_prefix'),
             ]
         })
 
@@ -61,6 +65,10 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'size': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('is_positive_integer'),
+            ],
+            'lfs_prefix': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_lfs_prefix'),
             ]
         })
 
@@ -82,7 +90,8 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             u'upload_has_sha256': validators.upload_has_sha256,
             u'upload_has_size': validators.upload_has_size,
             u'upload_has_lfs_prefix': validators.upload_has_lfs_prefix,
-            u'valid_sha256': validators.valid_sha256
+            u'valid_sha256': validators.valid_sha256,
+            u'valid_lfs_prefix': validators.valid_lfs_prefix,
         }
 
     # IConfigurer

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -31,7 +31,11 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
                 toolkit.get_validator('upload_has_sha256'),
                 toolkit.get_validator('upload_has_size'),
                 toolkit.get_validator('upload_has_lfs_prefix')
-                ]
+                ],
+            'sha256': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_sha256')
+            ]
         })
 
         return schema
@@ -45,7 +49,11 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
                 toolkit.get_validator('upload_has_sha256'),
                 toolkit.get_validator('upload_has_size'),
                 toolkit.get_validator('upload_has_lfs_prefix')
-                ]
+                ],
+            'sha256': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_sha256')
+            ]
         })
 
         return schema
@@ -65,7 +73,8 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
         return {
             u'upload_has_sha256': validators.upload_has_sha256,
             u'upload_has_size': validators.upload_has_size,
-            u'upload_has_lfs_prefix': validators.upload_has_lfs_prefix
+            u'upload_has_lfs_prefix': validators.upload_has_lfs_prefix,
+            u'valid_sha256': validators.valid_sha256
         }
 
     # IConfigurer

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -29,7 +29,8 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'url_type': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('upload_has_sha256'),
-                toolkit.get_validator('upload_has_size')
+                toolkit.get_validator('upload_has_size'),
+                toolkit.get_validator('upload_has_lfs_prefix')
                 ]
         })
 
@@ -42,7 +43,8 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
             'url_type': [
                 toolkit.get_validator('ignore_missing'),
                 toolkit.get_validator('upload_has_sha256'),
-                toolkit.get_validator('upload_has_size')
+                toolkit.get_validator('upload_has_size'),
+                toolkit.get_validator('upload_has_lfs_prefix')
                 ]
         })
 
@@ -63,6 +65,7 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
         return {
             u'upload_has_sha256': validators.upload_has_sha256,
             u'upload_has_size': validators.upload_has_size,
+            u'upload_has_lfs_prefix': validators.upload_has_lfs_prefix
         }
 
     # IConfigurer

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -53,12 +53,12 @@ class ExternalStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm)
     def is_fallback(self):
         # Return True to register this plugin as the default handler for
         # package types not handled by any other IDatasetForm plugin.
-        return False
+        return True
 
     def package_types(self):
         # This plugin doesn't handle any special package types, it just
         # registers itself as the default (above).
-        return ['dataset']
+        return []
 
     # IValidators
     def get_validators(self):

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -68,3 +68,45 @@ def test_no_validation_error_if_all_fields_are_set():
                 }
             ]
         )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_wrong_sha256():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'wrong_sha256',
+                    'size': 123456
+                }
+            ]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_size_not_positive_integer():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'size': -12
+                }
+            ]
+        )
+
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'size': 0
+                }
+            ]
+        )

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -79,7 +79,8 @@ def test_validation_error_if_wrong_sha256():
                     'url': '/my/file.csv',
                     'url_type': 'upload',
                     'sha256': 'wrong_sha256',
-                    'size': 123456
+                    'size': 123456,
+                    'lfs_prefix': 'lfs/prefix'
                 }
             ]
         )
@@ -94,7 +95,8 @@ def test_validation_error_if_size_not_positive_integer():
                     'url': '/my/file.csv',
                     'url_type': 'upload',
                     'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
-                    'size': -12
+                    'size': -12,
+                    'lfs_prefix': 'lfs/prefix'
                 }
             ]
         )
@@ -106,7 +108,24 @@ def test_validation_error_if_size_not_positive_integer():
                     'url': '/my/file.csv',
                     'url_type': 'upload',
                     'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
-                    'size': 0
+                    'size': 0,
+                    'lfs_prefix': 'lfs/prefix'
+                }
+            ]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_empty_lfs_prefix():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'size': 123456,
+                    'lfs_prefix': ''
                 }
             ]
         )

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -1,0 +1,48 @@
+import ckan.plugins.toolkit as toolkit
+import pytest
+from ckan.tests import factories
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_not_sha256():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {'url': '/my/file.csv', 'url_type': 'upload', 'size': 12345}
+            ]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_not_size_on_uploads():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'
+                }
+            ]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_no_validation_error_if_not_upload():
+    factories.Dataset(
+            resources=[{'url': 'https://www.example.com', 'url_type': ''}]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_no_validation_error_if_sha256_and_size_are_set():
+    factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'size': 12345
+                }
+            ]
+        )

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -57,17 +57,21 @@ def test_no_validation_error_if_not_upload():
 
 @pytest.mark.usefixtures("clean_db")
 def test_no_validation_error_if_all_fields_are_set():
-    factories.Dataset(
-            resources=[
-                {
-                    'url': '/my/file.csv',
-                    'url_type': 'upload',
-                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
-                    'size': 12345,
-                    'lfs_prefix': 'lfs/prefix'
-                }
-            ]
-        )
+    dataset = factories.Dataset(
+        resources=[
+            {
+                'url': '/my/file.csv',
+                'url_type': 'upload',
+                'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                'size': 12345,
+                'lfs_prefix': 'lfs/prefix'
+            }
+        ]
+    )
+
+    assert dataset['resources'][0]['sha256'] == 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'
+    assert dataset['resources'][0]['size'] == 12345
+    assert dataset['resources'][0]['lfs_prefix'] == 'lfs/prefix'
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/ckanext/external_storage/tests/test_actions.py
+++ b/ckanext/external_storage/tests/test_actions.py
@@ -8,7 +8,12 @@ def test_validation_error_if_not_sha256():
     with pytest.raises(toolkit.ValidationError):
         factories.Dataset(
             resources=[
-                {'url': '/my/file.csv', 'url_type': 'upload', 'size': 12345}
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'size': 12345,
+                    'lfs_prefix': 'lfs/prefix'
+                }
             ]
         )
 
@@ -21,7 +26,23 @@ def test_validation_error_if_not_size_on_uploads():
                 {
                     'url': '/my/file.csv',
                     'url_type': 'upload',
-                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'lfs_prefix': 'lfs/prefix'
+                }
+            ]
+        )
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_validation_error_if_not_lfs_prefix_on_uploads():
+    with pytest.raises(toolkit.ValidationError):
+        factories.Dataset(
+            resources=[
+                {
+                    'url': '/my/file.csv',
+                    'url_type': 'upload',
+                    'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
+                    'size': 123456
                 }
             ]
         )
@@ -35,14 +56,15 @@ def test_no_validation_error_if_not_upload():
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_no_validation_error_if_sha256_and_size_are_set():
+def test_no_validation_error_if_all_fields_are_set():
     factories.Dataset(
             resources=[
                 {
                     'url': '/my/file.csv',
                     'url_type': 'upload',
                     'sha256': 'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919',
-                    'size': 12345
+                    'size': 12345,
+                    'lfs_prefix': 'lfs/prefix'
                 }
             ]
         )

--- a/ckanext/external_storage/tests/test_validators.py
+++ b/ckanext/external_storage/tests/test_validators.py
@@ -43,7 +43,7 @@ def test_upload_has_lfs_prefix():
     flattened_data = {
         (u'resources', 0, u'url_type'): u'upload',
         (u'resources', 0, u'url'): u'/my/file.csv',
-        (u'resources', 0, u'__extras'): {'lfs_prefix': u'lfs/prefix'}
+        (u'resources', 0, u'lfs_prefix'): u'lfs/prefix'
     }
     validators.upload_has_lfs_prefix(key, flattened_data, {}, {})
 
@@ -60,6 +60,13 @@ def test_valid_sha256():
 
     with pytest.raises(Invalid):
         validators.valid_sha256('wrong_sha256')
+
+
+def test_valid_lfs_prefix():
+    validators.valid_lfs_prefix("lfs/prefix")
+
+    with pytest.raises(Invalid):
+        validators.valid_lfs_prefix("")
 
 
 def test_sha256_doesnt_raise_if_not_upload():

--- a/ckanext/external_storage/tests/test_validators.py
+++ b/ckanext/external_storage/tests/test_validators.py
@@ -6,7 +6,7 @@ def test_upload_has_sha256():
     flattened_data = {
         (u'resources', 0, u'url_type'): u'upload',
         (u'resources', 0, u'url'): u'/my/file.csv',
-        (u'resources', 0, u'__extras'): {'sha256': u'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'}
+        (u'resources', 0, u'sha256'): u'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'
     }
     validators.upload_has_sha256(key, flattened_data, {}, {})
 
@@ -29,6 +29,10 @@ def test_upload_has_lfs_prefix():
         (u'resources', 0, u'__extras'): {'lfs_prefix': u'lfs/prefix'}
     }
     validators.upload_has_lfs_prefix(key, flattened_data, {}, {})
+
+
+def test_valid_sha256():
+    validators.valid_sha256('cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919')
 
 
 def test_sha256_doesnt_raise_if_not_upload():

--- a/ckanext/external_storage/tests/test_validators.py
+++ b/ckanext/external_storage/tests/test_validators.py
@@ -21,6 +21,16 @@ def test_upload_has_size():
     validators.upload_has_size(key, flattened_data, {}, {})
 
 
+def test_upload_has_lfs_prefix():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'upload',
+        (u'resources', 0, u'url'): u'/my/file.csv',
+        (u'resources', 0, u'__extras'): {'lfs_prefix': u'lfs/prefix'}
+    }
+    validators.upload_has_lfs_prefix(key, flattened_data, {}, {})
+
+
 def test_sha256_doesnt_raise_if_not_upload():
     key = ('resources', 0, 'url_type')
     flattened_data = {
@@ -37,3 +47,12 @@ def test_size_doesnt_raise_if_not_upload():
         (u'resources', 0, u'url'): u'https://www.google.com',
     }
     validators.upload_has_size(key, flattened_data, {}, {})
+
+
+def test_lfs_prefix_doesnt_raise_if_not_upload():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'',
+        (u'resources', 0, u'url'): u'https://www.google.com',
+    }
+    validators.upload_has_lfs_prefix(key, flattened_data, {}, {})

--- a/ckanext/external_storage/tests/test_validators.py
+++ b/ckanext/external_storage/tests/test_validators.py
@@ -1,3 +1,6 @@
+import pytest
+from ckan.plugins.toolkit import Invalid
+
 from ckanext.external_storage import validators
 
 
@@ -10,6 +13,13 @@ def test_upload_has_sha256():
     }
     validators.upload_has_sha256(key, flattened_data, {}, {})
 
+    with pytest.raises(Invalid):
+        flattened_data = {
+            (u'resources', 0, u'url_type'): u'upload',
+            (u'resources', 0, u'url'): u'/my/file.csv',
+        }
+        validators.upload_has_sha256(key, flattened_data, {}, {})
+
 
 def test_upload_has_size():
     key = ('resources', 0, 'url_type')
@@ -19,6 +29,13 @@ def test_upload_has_size():
         (u'resources', 0, u'size'): 123456
     }
     validators.upload_has_size(key, flattened_data, {}, {})
+
+    with pytest.raises(Invalid):
+        flattened_data = {
+            (u'resources', 0, u'url_type'): u'upload',
+            (u'resources', 0, u'url'): u'/my/file.csv',
+        }
+        validators.upload_has_size(key, flattened_data, {}, {})
 
 
 def test_upload_has_lfs_prefix():
@@ -30,9 +47,19 @@ def test_upload_has_lfs_prefix():
     }
     validators.upload_has_lfs_prefix(key, flattened_data, {}, {})
 
+    with pytest.raises(Invalid):
+        flattened_data = {
+            (u'resources', 0, u'url_type'): u'upload',
+            (u'resources', 0, u'url'): u'/my/file.csv'
+        }
+        validators.upload_has_lfs_prefix(key, flattened_data, {}, {})
+
 
 def test_valid_sha256():
     validators.valid_sha256('cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919')
+
+    with pytest.raises(Invalid):
+        validators.valid_sha256('wrong_sha256')
 
 
 def test_sha256_doesnt_raise_if_not_upload():

--- a/ckanext/external_storage/tests/test_validators.py
+++ b/ckanext/external_storage/tests/test_validators.py
@@ -1,0 +1,39 @@
+from ckanext.external_storage import validators
+
+
+def test_upload_has_sha256():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'upload',
+        (u'resources', 0, u'url'): u'/my/file.csv',
+        (u'resources', 0, u'__extras'): {'sha256': u'cc71500070cf26cd6e8eab7c9eec3a937be957d144f445ad24003157e2bd0919'}
+    }
+    validators.upload_has_sha256(key, flattened_data, {}, {})
+
+
+def test_upload_has_size():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'upload',
+        (u'resources', 0, u'url'): u'/my/file.csv',
+        (u'resources', 0, u'size'): 123456
+    }
+    validators.upload_has_size(key, flattened_data, {}, {})
+
+
+def test_sha256_doesnt_raise_if_not_upload():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'',
+        (u'resources', 0, u'url'): u'https://www.google.com',
+    }
+    validators.upload_has_sha256(key, flattened_data, {}, {})
+
+
+def test_size_doesnt_raise_if_not_upload():
+    key = ('resources', 0, 'url_type')
+    flattened_data = {
+        (u'resources', 0, u'url_type'): u'',
+        (u'resources', 0, u'url'): u'https://www.google.com',
+    }
+    validators.upload_has_size(key, flattened_data, {}, {})

--- a/ckanext/external_storage/validators.py
+++ b/ckanext/external_storage/validators.py
@@ -1,0 +1,16 @@
+from ckan.plugins.toolkit import Invalid
+
+
+def upload_has_sha256(key, flattened_data, errors, context):
+    __extras_key = (key[0], key[1], '__extras')
+    if flattened_data[key] == 'upload':
+        if __extras_key not in flattened_data:
+            raise Invalid("Resource's sha256 field cannot be missing for uploads.")
+        elif 'sha256' not in flattened_data[__extras_key]:
+            raise Invalid("Resource's sha256 field cannot be missing for uploads.")
+
+
+def upload_has_size(key, flattened_data, errors, context):
+    if flattened_data[key] == 'upload':
+        if (key[0], key[1], 'size') not in flattened_data:
+            raise Invalid("Resource's size field cannot be missing for uploads.")

--- a/ckanext/external_storage/validators.py
+++ b/ckanext/external_storage/validators.py
@@ -2,8 +2,8 @@ from ckan.plugins.toolkit import Invalid
 
 
 def upload_has_sha256(key, flattened_data, errors, context):
-    __extras_key = (key[0], key[1], '__extras')
     if flattened_data[key] == 'upload':
+        __extras_key = (key[0], key[1], '__extras')
         if __extras_key not in flattened_data:
             raise Invalid("Resource's sha256 field cannot be missing for uploads.")
         elif 'sha256' not in flattened_data[__extras_key]:
@@ -14,3 +14,12 @@ def upload_has_size(key, flattened_data, errors, context):
     if flattened_data[key] == 'upload':
         if (key[0], key[1], 'size') not in flattened_data:
             raise Invalid("Resource's size field cannot be missing for uploads.")
+
+
+def upload_has_lfs_prefix(key, flattened_data, errors, context):
+    if flattened_data[key] == 'upload':
+        __extras_key = (key[0], key[1], '__extras')
+        if __extras_key not in flattened_data:
+            raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")
+        elif 'lfs_prefix' not in flattened_data[__extras_key]:
+            raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")

--- a/ckanext/external_storage/validators.py
+++ b/ckanext/external_storage/validators.py
@@ -3,11 +3,13 @@ from ckan.plugins.toolkit import Invalid
 
 def upload_has_sha256(key, flattened_data, errors, context):
     if flattened_data[key] == 'upload':
-        __extras_key = (key[0], key[1], '__extras')
-        if __extras_key not in flattened_data:
+        if (key[0], key[1], 'sha256') not in flattened_data:
             raise Invalid("Resource's sha256 field cannot be missing for uploads.")
-        elif 'sha256' not in flattened_data[__extras_key]:
-            raise Invalid("Resource's sha256 field cannot be missing for uploads.")
+
+
+def valid_sha256(value):
+    if not _is_hex_str(value, 64):
+        raise Invalid("Resource's sha256 is not a valid hex-only string.")
 
 
 def upload_has_size(key, flattened_data, errors, context):
@@ -23,3 +25,31 @@ def upload_has_lfs_prefix(key, flattened_data, errors, context):
             raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")
         elif 'lfs_prefix' not in flattened_data[__extras_key]:
             raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")
+
+
+def _is_hex_str(value, chars=40):
+    # type: (str, int) -> bool
+    """Check if a string is a hex-only string of exactly :param:`chars` characters length.
+    This is useful to verify that a string contains a valid SHA, MD5 or UUID-like value.
+    >>> _is_hex_str('0f1128046248f83dc9b9ab187e16fad0ff596128f1524d05a9a77c4ad932f10a', 64)
+    True
+    >>> _is_hex_str('0f1128046248f83dc9b9ab187e16fad0ff596128f1524d05a9a77c4ad932f10a', 32)
+    False
+    >>> _is_hex_str('0f1128046248f83dc9b9ab187e1xfad0ff596128f1524d05a9a77c4ad932f10a', 64)
+    False
+    >>> _is_hex_str('ef42bab1191da272f13935f78c401e3de0c11afb')
+    True
+    >>> _is_hex_str('ef42bab1191da272f13935f78c401e3de0c11afb'.upper())
+    True
+    >>> _is_hex_str('ef42bab1191da272f13935f78c401e3de0c11afb', 64)
+    False
+    >>> _is_hex_str('ef42bab1191da272f13935.78c401e3de0c11afb')
+    False
+    """
+    if len(value) != chars:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True

--- a/ckanext/external_storage/validators.py
+++ b/ckanext/external_storage/validators.py
@@ -10,6 +10,7 @@ def upload_has_sha256(key, flattened_data, errors, context):
 def valid_sha256(value):
     if not _is_hex_str(value, 64):
         raise Invalid("Resource's sha256 is not a valid hex-only string.")
+    return value
 
 
 def upload_has_size(key, flattened_data, errors, context):
@@ -27,6 +28,7 @@ def upload_has_lfs_prefix(key, flattened_data, errors, context):
 def valid_lfs_prefix(value):
     if value == "":
         raise Invalid("Resource's lfs_prefix field cannot be empty.")
+    return value
 
 
 def _is_hex_str(value, chars=40):

--- a/ckanext/external_storage/validators.py
+++ b/ckanext/external_storage/validators.py
@@ -20,11 +20,13 @@ def upload_has_size(key, flattened_data, errors, context):
 
 def upload_has_lfs_prefix(key, flattened_data, errors, context):
     if flattened_data[key] == 'upload':
-        __extras_key = (key[0], key[1], '__extras')
-        if __extras_key not in flattened_data:
+        if (key[0], key[1], 'lfs_prefix') not in flattened_data:
             raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")
-        elif 'lfs_prefix' not in flattened_data[__extras_key]:
-            raise Invalid("Resource's lfs_prefix field cannot be missing for uploads.")
+
+
+def valid_lfs_prefix(value):
+    if value == "":
+        raise Invalid("Resource's lfs_prefix field cannot be empty.")
 
 
 def _is_hex_str(value, chars=40):


### PR DESCRIPTION
`sha256`, `size` and `lfs_prefix` attributes are key to be able to download correctly so we need to validate they're being set correctly when creating a resource via UI or API.

Nowadays all the logic and validation is in the FronEnd, this will move the logic to the backed so API users can also have a validation.

Note: the creation and the structure of the `lfs_prefix` depends on each instance so I'm just validating that the field exist in the resource schema. Let me know your thoughts!