### PR TITLE
Support of resource download from past activities (revisions)

### DIFF
--- a/ckanext/external_storage/authz.py
+++ b/ckanext/external_storage/authz.py
@@ -19,6 +19,8 @@ def check_object_permissions(id, dataset_id=None, organization_id=None):
     This wrap's ckanext-authz-service's default logic for checking resource
     by checking for global-prefix/dataset-uuid/* style object scopes.
     """
+    # support for resource_id/activity_id
+    id = id.split('/')[0]
     if dataset_id and organization_id and organization_id == helpers.storage_namespace():
         log.debug("Requesting authorization for object: %s/%s in namespace %s", dataset_id, id, organization_id)
         dataset = toolkit.get_action('package_show')(get_user_context(), {'id': dataset_id})
@@ -83,7 +85,6 @@ def _get_resource_storage_id(organization_id, dataset_id, resource_id, activity_
         activity = toolkit.get_action(u'activity_show')(
                     context, {u'id': activity_id, u'include_data': True})
         activity_dataset = activity['data']['package']
-        assert activity_dataset['id'] == dataset_id
         activity_resources = activity_dataset['resources']
         for r in activity_resources:
             if r['id'] == resource_id:

--- a/ckanext/external_storage/blueprints.py
+++ b/ckanext/external_storage/blueprints.py
@@ -1,9 +1,14 @@
 """ckanext-external-storage Flask blueprints
 """
+import logging
+
+from ckan.common import request
 from ckan.plugins import toolkit
 from flask import Blueprint
 
 from .download_handler import call_download_handlers, call_pre_download_handlers, get_context
+
+log = logging.getLogger(__name__)
 
 blueprint = Blueprint(
     'extstorage',
@@ -11,23 +16,38 @@ blueprint = Blueprint(
 )
 
 
-def download(id, resource_id, filename=None):
-    """Download resource blueprint
-
-    This calls all registered download handlers in order, until
-    a response is returned to the user
-    """
+def download(dataset_id, resource_id, filename=None):
+    activity_id = request.args.get('activity_id')
+    log.error("UNAIDS resource download")
     context = get_context()
-
+    resource = None
     try:
-        resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
-        if id != resource['package_id']:
-            return toolkit.abort(404, toolkit._('Resource not found belonging to package'))
+        package = toolkit.get_action('package_show')(context, {'id': dataset_id})
+    except toolkit.ObjectNotFound:
+        return toolkit.abort(404, toolkit._('Dataset not found'))
+    if activity_id:
+        try:
+            activity = toolkit.get_action(u'activity_show')(
+                context, {u'id': activity_id, u'include_data': True})
+            activity_dataset = activity['data']['package']
+            assert activity_dataset['id'] == dataset_id
+            activity_resources = activity_dataset['resources']
+            for r in activity_resources:
+                if r['id'] == resource_id:
+                    resource = r
+                    package = activity_dataset
+                    break
 
-        package = toolkit.get_action('package_show')(context, {'id': id})
+        except toolkit.NotFound:
+            toolkit.abort(404, toolkit._(u'Activity not found'))
+    try:
+        if not resource:
+            resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
+            if dataset_id != resource['package_id']:
+                return toolkit.abort(404, toolkit._('Resource not found belonging to package'))
 
-        resource = call_pre_download_handlers(resource, package)
-        return call_download_handlers(resource, package, filename)
+        resource = call_pre_download_handlers(resource, package, activity_id=activity_id)
+        return call_download_handlers(resource, package, filename, activity_id=activity_id)
 
     except toolkit.ObjectNotFound:
         return toolkit.abort(404, toolkit._('Resource not found'))
@@ -35,5 +55,5 @@ def download(id, resource_id, filename=None):
         return toolkit.abort(401, toolkit._('Not authorized to read resource {0}'.format(resource_id)))
 
 
-blueprint.add_url_rule(u'/dataset/<id>/resource/<resource_id>/download', view_func=download)
-blueprint.add_url_rule(u'/dataset/<id>/resource/<resource_id>/download/<filename>', view_func=download)
+blueprint.add_url_rule(u'/dataset/<dataset_id>/resource/<resource_id>/download', view_func=download)
+blueprint.add_url_rule(u'/dataset/<dataset_id>/resource/<resource_id>/download/<filename>', view_func=download)

--- a/ckanext/external_storage/blueprints.py
+++ b/ckanext/external_storage/blueprints.py
@@ -17,6 +17,11 @@ blueprint = Blueprint(
 
 
 def download(dataset_id, resource_id, filename=None):
+    """Download resource blueprint
+
+    This calls all registered download handlers in order, until
+    a response is returned to the user
+    """
     activity_id = request.args.get('activity_id')
     log.error("UNAIDS resource download")
     context = get_context()

--- a/ckanext/external_storage/download_handler.py
+++ b/ckanext/external_storage/download_handler.py
@@ -16,7 +16,7 @@ def get_context():
     }
 
 
-def call_pre_download_handlers(resource, package):
+def call_pre_download_handlers(resource, package, activity_id=None):
     """Call all registered plugins pre-download callback
     """
     for plugin in plugins.PluginImplementations(IResourceDownloadHandler):
@@ -29,20 +29,20 @@ def call_pre_download_handlers(resource, package):
     return resource
 
 
-def call_download_handlers(resource, package, filename=None):
+def call_download_handlers(resource, package, filename=None, activity_id=None):
     """Call all registered plugins download handlers
     """
     for plugin in plugins.PluginImplementations(IResourceDownloadHandler):
         if not hasattr(plugin, 'resource_download'):
             continue
-        response = plugin.resource_download(resource, package, filename)
+        response = plugin.resource_download(resource, package, filename, activity_id=activity_id)
         if response:
             return response
 
     return fallback_download_method(resource)
 
 
-def download_handler(resource, _, filename=None):
+def download_handler(resource, _, filename=None, activity_id=None):
     """Get the download URL from LFS server and redirect the user there
     """
     if resource.get('url_type') != 'upload' or not resource.get('lfs_prefix'):
@@ -50,7 +50,8 @@ def download_handler(resource, _, filename=None):
 
     context = get_context()
     data_dict = {'resource': resource,
-                 'filename': filename}
+                 'filename': filename,
+                 'activity_id': activity_id}
     resource_download_spec = tk.get_action('get_resource_download_spec')(context, data_dict)
     href = resource_download_spec.get('href')
 

--- a/ckanext/external_storage/helpers.py
+++ b/ckanext/external_storage/helpers.py
@@ -1,5 +1,6 @@
 """Template helpers for ckanext-external-storage
 """
+import logging
 from os import path
 from typing import Any, Dict, Optional
 
@@ -8,6 +9,8 @@ from six.moves.urllib.parse import urlparse
 
 SERVER_URL_CONF_KEY = 'ckanext.external_storage.storage_service_url'
 STORAGE_NAMESPACE_CONF_KEY = 'ckanext.external_storage.storage_namespace'
+
+log = logging.getLogger(__name__)
 
 
 def resource_storage_prefix(package_name, org_name=None):
@@ -19,7 +22,7 @@ def resource_storage_prefix(package_name, org_name=None):
     return '{}/{}'.format(org_name, package_name)
 
 
-def resource_authz_scope(package_name, actions=None, org_name=None, resource_id=None):
+def resource_authz_scope(package_name, actions=None, org_name=None, resource_id=None, activity_id=None):
     # type: (str, Optional[str], Optional[str], Optional[str]) -> str
     """Get the authorization scope for package resources
     """
@@ -27,7 +30,19 @@ def resource_authz_scope(package_name, actions=None, org_name=None, resource_id=
         actions = 'read,write'
     if resource_id is None:
         resource_id = '*'
-    return 'obj:{}/{}:{}'.format(resource_storage_prefix(package_name, org_name), resource_id, actions)
+    scope = 'obj:{}/{}:{}'.format(
+        resource_storage_prefix(package_name, org_name),
+        _resource_version(resource_id, activity_id),
+        actions
+    )
+    return scope
+
+
+def _resource_version(resource_id, activity_id):
+    result = resource_id
+    if activity_id:
+        result += "/{}".format(activity_id)
+    return result
 
 
 def server_url():

--- a/ckanext/external_storage/interfaces.py
+++ b/ckanext/external_storage/interfaces.py
@@ -9,7 +9,7 @@ class IResourceDownloadHandler(Interface):
     """A CKAN plugin interface for registering resource download handler plugins
     """
 
-    def pre_resource_download(self, resource, package):
+    def pre_resource_download(self, resource, package, activity_id=None):
         # type: (Dict[str, Any], Dict[str, Any], Optional[str]) -> Optional[Dict[str, Any]]
         """Pre-resource download function
 
@@ -27,8 +27,8 @@ class IResourceDownloadHandler(Interface):
         """
         pass
 
-    def resource_download(self, resource, package, filename=None):
-        # type: (Dict[str, Any], Dict[str, Any], Optional[str]) -> Any
+    def resource_download(self, resource, package, filename=None, activity_id=None):
+        # type: (Dict[str, Any], Dict[str, Any], Optional[str], Optional[str]) -> Any
         """Download a resource
 
         Called to download a resource, with the resource, package and filename

--- a/ckanext/external_storage/plugin.py
+++ b/ckanext/external_storage/plugin.py
@@ -66,5 +66,5 @@ class ExternalStoragePlugin(plugins.SingletonPlugin):
 
     # IResourceDownloadHandler
 
-    def resource_download(self, resource, package, filename=None):
-        return download_handler(resource, package, filename)
+    def resource_download(self, resource, package, filename=None, activity_id=None):
+        return download_handler(resource, package, filename, activity_id)


### PR DESCRIPTION
I was trying to decorate blob-storage `download` blueprints to support accessing giftless files for arbitrary activity_id of resource history. In other words to support the following arg `activity_id`:
```
/dataset/<dataset_id>/resource/<resource_id>/download/<filename>?activity_id=<activity_id>
http://ckan/dataset/xxx/resource/yyy/download/tomek.txt?activity_id=zzz
```
I thought that it's going to be an easy job as `IResourceDownloadHandler.resource_download` accept dataset and resource in a dictionary form. I have created a simple wrapper which replace the resource dictionary with the old version fetched from activity.

It wouldn't work due to authentication to giftless which bypasses dataset/resource dicts and work only with dataset_id and resource_id. This means that in the end of the day when we receive granted scopes translated to `sha256` we get the hash of **current** resource version ("latest") which doesn't match requested object `sha256` which comes from the `activity_id`.

I hope I did manage to shade some light on the issue. I have also added some inline comments to this PR.
This PR is just a rough PoC. This allowed me to successfully download different versions of a single resource from Activity Stream.
I would like to ask for early feedback if my approach is valid or otherwise potential suggestions how this feature could be implemented differently.
CC: @shevron @rufuspollock 