### PR TITLE
Don't fail if file not found in fallback handler

### DIFF
--- a/ckanext/blob_storage/download_handler.py
+++ b/ckanext/blob_storage/download_handler.py
@@ -1,3 +1,5 @@
+import os
+
 from ckan import model, plugins
 from ckan.lib import uploader
 from ckan.plugins import toolkit as tk
@@ -66,7 +68,10 @@ def fallback_download_method(resource):
     if resource.get('url_type') == 'upload':
         upload = uploader.get_resource_uploader(resource)
         filepath = upload.get_path(resource[u'id'])
-        return send_file(filepath)
+        if os.path.exists(filepath):
+            return send_file(filepath)
+        else:
+            return tk.abort(404, tk._('File not found'))
     elif u'url' not in resource:
         return tk.abort(404, tk._('No download is available'))
 


### PR DESCRIPTION
If the blob storage extension can not find a file remotely, it falls back to the default local storage backend. If for some reason this
backend can't find the file either (eg because of a corrupted resource that changed from link to upload) it fails with an IO exception. This changes it to emit a 404 error instead.