### PR TITLE
Support for context passed as kwarg in newer authz-service version

### DIFF
--- a/ckanext/blob_storage/authz.py
+++ b/ckanext/blob_storage/authz.py
@@ -13,17 +13,19 @@ from . import helpers
 log = logging.getLogger(__name__)
 
 
-def check_object_permissions(id, dataset_id=None, organization_id=None):
+def check_object_permissions(id, dataset_id=None, organization_id=None, context=None):
     """Check object (resource in storage) permissions
 
     This wrap's ckanext-authz-service's default logic for checking resource
     by checking for global-prefix/dataset-uuid/* style object scopes.
     """
+    if not context:
+        context = get_user_context()
     # support for resource_id/activity_id
     id = id.split('/')[0]
     if dataset_id and organization_id and organization_id == helpers.storage_namespace():
         log.debug("Requesting authorization for object: %s/%s in namespace %s", dataset_id, id, organization_id)
-        dataset = toolkit.get_action('package_show')(get_user_context(), {'id': dataset_id})
+        dataset = toolkit.get_action('package_show')(context, {'id': dataset_id})
         dataset_id = dataset['name']
         try:
             organization_id = dataset['organization']['name']
@@ -31,7 +33,7 @@ def check_object_permissions(id, dataset_id=None, organization_id=None):
             organization_id = None  # Dataset has no organization
         log.debug("Real resource path is res:%s/%s/%s", organization_id, dataset_id, id)
 
-    return resource_authz.check_resource_permissions(id, dataset_id, organization_id)
+    return resource_authz.check_resource_permissions(id, dataset_id, organization_id, context=context)
 
 
 def object_id_parser(*args, **kwargs):

--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,5 @@ requests==2.*,>=2.23.0
 six==1.14.*
 typing==3.7.*
 giftless-client==0.1.*
--r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
-git+https://github.com/datopian/ckanext-authz-service.git@v0.1.2#egg=ckanext-authz-service
+-r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
+git+https://github.com/datopian/ckanext-authz-service.git@v0.1.5#egg=ckanext-authz-service

--- a/requirements.py2.txt
+++ b/requirements.py2.txt
@@ -10,7 +10,7 @@ cffi==1.14.0
     # via cryptography
 chardet==3.0.4
     # via requests
-git+https://github.com/datopian/ckanext-authz-service.git@v0.1.2#egg=ckanext-authz-service
+git+https://github.com/datopian/ckanext-authz-service.git@v0.1.5#egg=ckanext-authz-service
     # via -r requirements.in
 click==7.1.2
     # via giftless-client
@@ -27,30 +27,30 @@ ipaddress==1.0.23
 pycparser==2.20
     # via cffi
 pyjwt[crypto]==1.7.1
-    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
 python-dateutil==2.8.1
     # via giftless-client
 pytz==2020.1
-    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
 pyyaml==5.3.1
-    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    # via -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
 requests==2.25.1
     # via
     #   -r requirements.in
     #   giftless-client
 six==1.14.0
     # via
-    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
     #   -r requirements.in
     #   cryptography
     #   python-dateutil
 typing-extensions==3.7.4.2
     # via
-    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
     #   giftless-client
 typing==3.7.4.1
     # via
-    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.2/requirements.in
+    #   -r https://raw.githubusercontent.com/datopian/ckanext-authz-service/v0.1.5/requirements.in
     #   -r requirements.in
     #   typing-extensions
 urllib3==1.25.9


### PR DESCRIPTION
@pdelboca Following a conversation from https://github.com/datopian/ckanext-blob-storage/pull/55 this PR make the blob storage compatible with latest changes done in authz-service (fixing issue https://github.com/datopian/ckanext-authz-service/issues/24)

In this PR I've upgraded authz-service to v1.5.0 but once a new release is tagged it should be bumped up to v1.6.0 which would include the fix for issue mentioned above.