### PR TITLE
Fix donwloads on Python 3. Make sure that the auth token is a str

### DIFF
--- a/ckanext/blob_storage/actions.py
+++ b/ckanext/blob_storage/actions.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from ckan.plugins import toolkit
 from giftless_client import LfsClient
 from giftless_client.exc import LfsError
+from six import ensure_text
 
 from . import helpers
 
@@ -152,7 +153,7 @@ def get_download_authz_token(context, org_name, package_name, resource_id, activ
     if len(authz_result['granted_scopes']) == 0:
         raise toolkit.NotAuthorized("You are not authorized to download this resource")
 
-    return authz_result['token']
+    return ensure_text(authz_result['token'])
 
 
 def _get_resource(context, data_dict):


### PR DESCRIPTION
On py3 the JWT token is a `bytes` object and if sent as is it gets sent as `b'exdf...'`. Giftless can't decode it and the download fails. This change ensures that the token is a `str` object both in py2 and py3