### PR TITLE
JS/CSS resource  loading compatibility for both 2.8 and 2.9 ckan version.

### DIFF
--- a/ckanext/blob_storage/fanstatic/resource.config
+++ b/ckanext/blob_storage/fanstatic/resource.config
@@ -1,0 +1,13 @@
+[IE conditional]
+
+[depends]
+
+main = base/main
+
+[groups]
+
+blob_storage =
+    css/main.3c074c8b.chunk.css
+    js/runtime-main.c155da57.js
+    js/2.60dfd475.chunk.js
+    js/main.c8e9dac3.chunk.js

--- a/ckanext/blob_storage/fanstatic/webassets.yml
+++ b/ckanext/blob_storage/fanstatic/webassets.yml
@@ -1,0 +1,14 @@
+blob-storage-css:
+  output: blob_storage/%(version)blob_storagecss
+  contents:
+    - css/main.3c074c8b.chunk.css
+
+blob_storage:
+  output: blob_storage/%(version)blob_storage.js
+  extra:
+    preload:
+      - blob-storage/blob-storage-css
+  contents:
+    - js/runtime-main.c155da57.js
+    - js/2.60dfd475.chunk.js
+    - js/main.c8e9dac3.chunk.js

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -105,8 +105,11 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # ITemplateHelpers
 
     def get_helpers(self):
-        return {'blob_storage_server_url': helpers.server_url,
-                'blob_storage_storage_namespace': helpers.storage_namespace}
+        return {
+            'blob_storage_server_url': helpers.server_url,
+            'blob_storage_storage_namespace': helpers.storage_namespace,
+            'ckan_29_or_higher' : plugins.toolkit.check_ckan_version(min_version='2.9.0')
+          }
 
     # IBlueprint
 

--- a/ckanext/blob_storage/plugin.py
+++ b/ckanext/blob_storage/plugin.py
@@ -108,7 +108,7 @@ class BlobStoragePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         return {
             'blob_storage_server_url': helpers.server_url,
             'blob_storage_storage_namespace': helpers.storage_namespace,
-            'ckan_29_or_higher' : plugins.toolkit.check_ckan_version(min_version='2.9.0')
+            'ckan_29_or_higher': plugins.toolkit.check_ckan_version(min_version='2.9.0')
           }
 
     # IBlueprint

--- a/ckanext/blob_storage/templates/assets_2.9.html
+++ b/ckanext/blob_storage/templates/assets_2.9.html
@@ -1,0 +1,1 @@
+{% asset 'blob-storage/blob_storage' %}

--- a/ckanext/blob_storage/templates/blob_storage/snippets/upload_module.html
+++ b/ckanext/blob_storage/templates/blob_storage/snippets/upload_module.html
@@ -1,8 +1,8 @@
-{% resource 'blob-storage/css/main.3c074c8b.chunk.css' %}
-
-{% resource 'blob-storage/js/runtime-main.c155da57.js' %}
-{% resource 'blob-storage/js/2.60dfd475.chunk.js' %}
-{% resource 'blob-storage/js/main.c8e9dac3.chunk.js' %}
+{% if h.ckan_29_or_higher %}
+  {% include 'assets_2.9.html' %}
+{% else %}
+  {% include 'resource_2.8.html' %}
+{% endif %}
 
 <div id="ResourceEditor"
      data-dataset-id="{{ pkg_id }}"

--- a/ckanext/blob_storage/templates/resource_2.8.html
+++ b/ckanext/blob_storage/templates/resource_2.8.html
@@ -1,0 +1,1 @@
+{% resource 'blob-storage/blob_storage' %}


### PR DESCRIPTION
CKAN v2.9 doesn’t support resource js/css imports. This PR includes both resource and assets importer so that it will compatible with both v2.9 and v2.8. 